### PR TITLE
New repo name

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -22,7 +22,7 @@ kramdown:
   smart_quotes:   lsquo,rsquo,ldquo,rdquo
   input:          GFM
 
-repository: https://github.com/codenvy/codenvy/
+repository: https://github.com/codenvy/docs/
 
 timezone: America/Los_Angeles
 

--- a/src/main/_includes/primary-nav-items.html
+++ b/src/main/_includes/primary-nav-items.html
@@ -9,6 +9,6 @@
     <a href="{{ base }}/docs/tutorials/multi-machine/index.html">Tutorials</a>
   </li>
   <li>
-    <a href="{{ site.repository }}/tree/master/docs"><span class="hide-on-mobiles">View on </span>GitHub</a>
+    <a href="{{ site.repository }}"><span class="hide-on-mobiles">View on </span>GitHub</a>
   </li>
 </ul>

--- a/src/main/_layouts/docs.html
+++ b/src/main/_layouts/docs.html
@@ -11,9 +11,9 @@ layout: default
         <article>
           <div class="improve right hide-on-mobiles">
             {% if page.tags[1] != null %} 
-            <a href="https://github.com/codenvy/{{ page.tags[1] }}-docs/blob/master/src/main/{{ page.path | replace_first:'/che','' }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
+            <a href="https://github.com/codenvy/docs/blob/master/src/main/{{ page.path | replace_first:'/che','' }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
             {% else %} 
-            <a href="https://github.com/{{ page.tags[0] }}/{{ page.tags[0] }}-docs/blob/master/src/main/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
+            <a href="https://github.com/{{ page.tags[0] }}/docs/blob/master/src/main/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
             {% endif %}
           </div>
           <div class="doc-title">


### PR DESCRIPTION
Our docs reference the old repo name codenvy/codenvy-docs. Changes to codenvy/docs. Also fixed `View on GitHub` link on top that referred to codenvy/codenvy.