### PR TITLE
Host/IP of workspace node must be public

### DIFF
--- a/src/main/_docs/admin-guide/admin-installation.md
+++ b/src/main/_docs/admin-guide/admin-installation.md
@@ -322,7 +322,7 @@ All ports are TCP unless otherwise noted.
 |8080|Codenvy Server
 
 ### Workspace Nodes
-You can add as many workspace nodes as required to handle additional demand.
+You can add as many workspace nodes as required to handle additional demand. When adding a workspace node the hostname/IP must be accessible to all clients who will connect to Codenvy.
 
 ![master_plus_node.png]({{base}}/docs/assets/imgs/codenvy/master_plus_node.png)
 


### PR DESCRIPTION
Added a reference in the workspace node section that the hostname / IP of the workspace node must be accessible to all clients who will connect to Codenvy.