### PR TITLE
Update labels-custom-assemblies.md

### DIFF
--- a/src/main/_docs/white-labels/labels-custom-assemblies.md
+++ b/src/main/_docs/white-labels/labels-custom-assemblies.md
@@ -72,6 +72,7 @@ index bed45eb..c97119a 100644
 #### Migration
   5.3 => 5.4 :
   1. Replace in assembly-ide-war/pom.xml
+  
   ```
           <dependency>
               <groupId>com.codenvy.onpremises</groupId>
@@ -80,7 +81,9 @@ index bed45eb..c97119a 100644
               <scope>provided</scope>
           </dependency>
   ```
+  
   with
+  
   ```
           <dependency>
               <groupId>com.codenvy.onpremises</groupId>

--- a/src/main/_docs/white-labels/labels-custom-assemblies.md
+++ b/src/main/_docs/white-labels/labels-custom-assemblies.md
@@ -69,8 +69,9 @@ index bed45eb..c97119a 100644
      <inherits name='org.eclipse.che.ide.extension.machine.Machine'/>
 ```
 
-#### Migration
-  5.3 => 5.4 :
+# Migrating from 5.3 to 5.4
+Changes in naming in 5.4 mean that if you have a 5.3 assembly you need to build for 5.4 you will have to alter the pom.xml:
+
   1. Replace in assembly-ide-war/pom.xml
   
   ```

--- a/src/main/_docs/white-labels/labels-custom-assemblies.md
+++ b/src/main/_docs/white-labels/labels-custom-assemblies.md
@@ -69,6 +69,27 @@ index bed45eb..c97119a 100644
      <inherits name='org.eclipse.che.ide.extension.machine.Machine'/>
 ```
 
+#### Migration
+  5.3 => 5.4 :
+  1. Replace in assembly-ide-war/pom.xml
+  ```
+          <dependency>
+              <groupId>com.codenvy.onpremises</groupId>
+              <artifactId>compiling-ide-war</artifactId>
+              <classifier>classes</classifier>
+              <scope>provided</scope>
+          </dependency>
+  ```
+  with
+  ```
+          <dependency>
+              <groupId>com.codenvy.onpremises</groupId>
+              <artifactId>assembly-ide-war</artifactId>
+              <classifier>classes</classifier>
+              <scope>provided</scope>
+          </dependency>
+  ```
+
 # Build Your Assembly
 
 ```shell  


### PR DESCRIPTION
Added migration information to documentation for replacing compiling-ide-war with assembly-ide-war in assembly-ide-war/pom.xml.

Replace
```
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
             <artifactId>compiling-ide-war</artifactId>
             <classifier>classes</classifier>
             <scope>provided</scope>
         </dependency>
 ```
 with
 ```
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
             <artifactId>assembly-ide-war</artifactId>
             <classifier>classes</classifier>
             <scope>provided</scope>
         </dependency>
 ```

Related to https://github.com/codenvy/codenvy/pull/1766
